### PR TITLE
refactor(ci): use of OpenID Connect

### DIFF
--- a/.github/workflows/ci-docs-autogen.yml
+++ b/.github/workflows/ci-docs-autogen.yml
@@ -5,10 +5,13 @@ on:
     branches:
       - main
 
-jobs:
-  autogen-docs:
-    runs-on: ubuntu-latest
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
 
+jobs:
+  forge-docs:
+    runs-on: ubuntu-latest
     environment:
       name: docs
       url: https://developers.morpho.xyz
@@ -18,11 +21,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Generate and upload docs
-        uses: morpho-labs/foundry-docs-aws@v1
+      - name: Generate & upload forge docs
+        uses: morpho-labs/foundry-docs-aws@v1.1.1
         with:
           aws-s3-bucket: ${{ secrets.AWS_S3_BUCKET }}
           aws-cloudfront-distribution-id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ vars.AWS_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
+          s3-acl: private


### PR DESCRIPTION
# Pull Request

- Ue of OpenID Connect instead of AWS credentials

The role is scoped to the docs environment with the following trust relationship:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::<account-i>:oidc-provider/token.actions.githubusercontent.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
                    "token.actions.githubusercontent.com:sub": "repo:morpho-org/morpho-v1:environment:docs"
                }
            }
        }
    ]
}
```

docs environment is also scoped to the main branch
![image](https://github.com/morpho-org/morpho-v1/assets/61523188/ea7547c0-ef54-4e20-917c-a7cb1381944a)
