### PR TITLE
Fix indexes caching issue

### DIFF
--- a/.github/actions/ci-foundry-upgrade/action.yml
+++ b/.github/actions/ci-foundry-upgrade/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
 
     - name: Install Foundry
-      uses: onbjerg/foundry-toolchain@v1
+      uses: foundry-rs/foundry-toolchain@v1
       with:
         version: nightly
 

--- a/.github/actions/ci-foundry/action.yml
+++ b/.github/actions/ci-foundry/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
 
     - name: Install Foundry
-      uses: onbjerg/foundry-toolchain@v1
+      uses: foundry-rs/foundry-toolchain@v1
       with:
         version: nightly
 

--- a/.github/workflows/ci-storage-check-aave-v2.yml
+++ b/.github/workflows/ci-storage-check-aave-v2.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 

--- a/.github/workflows/ci-storage-check-compound.yml
+++ b/.github/workflows/ci-storage-check-compound.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 

--- a/.github/workflows/ci-storage-snapshot-check-aave-v2.yml
+++ b/.github/workflows/ci-storage-snapshot-check-aave-v2.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 

--- a/.github/workflows/ci-storage-snapshot-check-compound.yml
+++ b/.github/workflows/ci-storage-snapshot-check-compound.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 

--- a/src/aave-v2/InterestRatesManager.sol
+++ b/src/aave-v2/InterestRatesManager.sol
@@ -53,8 +53,6 @@ contract InterestRatesManager is IInterestRatesManager, MorphoStorage {
     function updateIndexes(address _poolToken) external {
         Types.PoolIndexes storage marketPoolIndexes = poolIndexes[_poolToken];
 
-        if (block.timestamp == marketPoolIndexes.lastUpdateTimestamp) return;
-
         Types.Market storage market = market[_poolToken];
         (uint256 newPoolSupplyIndex, uint256 newPoolBorrowIndex) = _getPoolIndexes(
             market.underlyingToken

--- a/src/compound/InterestRatesManager.sol
+++ b/src/compound/InterestRatesManager.sol
@@ -52,8 +52,6 @@ contract InterestRatesManager is IInterestRatesManager, MorphoStorage {
     function updateP2PIndexes(address _poolToken) external {
         Types.LastPoolIndexes storage poolIndexes = lastPoolIndexes[_poolToken];
 
-        if (block.number == poolIndexes.lastUpdateBlockNumber) return;
-
         Types.MarketParameters memory marketParams = marketParameters[_poolToken];
 
         uint256 poolSupplyIndex = ICToken(_poolToken).exchangeRateCurrent();

--- a/src/compound/lens/IndexesLens.sol
+++ b/src/compound/lens/IndexesLens.sol
@@ -179,7 +179,7 @@ abstract contract IndexesLens is LensStorage {
     {
         marketParameters = morpho.marketParameters(_poolToken);
 
-        if (!_updated || block.number == _lastPoolIndexes.lastUpdateBlockNumber) {
+        if (!_updated) {
             return (
                 morpho.p2pSupplyIndex(_poolToken),
                 morpho.p2pBorrowIndex(_poolToken),

--- a/test/aave-v2/TestLens.t.sol
+++ b/test/aave-v2/TestLens.t.sol
@@ -1658,4 +1658,40 @@ contract TestLens is TestSetup {
         morpho.setIsLiquidateBorrowPaused(aDai, true);
         assertTrue(lens.getMarketPauseStatus(aDai).isLiquidateBorrowPaused);
     }
+
+    function testPoolIndexGrowthInsideBlock() public {
+        supplier1.approve(dai, type(uint256).max);
+        supplier1.supply(aDai, 10 ether);
+
+        uint256 poolSupplyIndexBefore = lens.getIndexes(aDai).poolSupplyIndex;
+
+        FlashLoan flashLoan = new FlashLoan(pool);
+        vm.prank(address(supplier2));
+        ERC20(dai).transfer(address(flashLoan), 10_000 ether); // To pay the premium.
+        flashLoan.callFlashLoan(dai, 10_000 ether);
+
+        uint256 poolSupplyIndexAfter = lens.getIndexes(aDai).poolSupplyIndex;
+
+        assertGt(poolSupplyIndexAfter, poolSupplyIndexBefore);
+    }
+
+    function testP2PIndexGrowthInsideBlock() public {
+        borrower1.approve(dai, type(uint256).max);
+        borrower1.supply(aDai, 10 ether);
+        borrower1.borrow(aDai, 5 ether);
+        setDefaultMaxGasForMatchingHelper(3e6, 3e6, 3e6, 0);
+        // Create delta.
+        borrower1.repay(aDai, type(uint256).max);
+
+        uint256 p2pSupplyIndexBefore = lens.getCurrentP2PSupplyIndex(aDai);
+
+        FlashLoan flashLoan = new FlashLoan(pool);
+        vm.prank(address(supplier2));
+        ERC20(dai).transfer(address(flashLoan), 10_000 ether); // To pay the premium.
+        flashLoan.callFlashLoan(dai, 10_000 ether);
+
+        uint256 p2pSupplyIndexAfter = lens.getCurrentP2PSupplyIndex(aDai);
+
+        assertGt(p2pSupplyIndexAfter, p2pSupplyIndexBefore);
+    }
 }

--- a/test/aave-v2/TestSupply.t.sol
+++ b/test/aave-v2/TestSupply.t.sol
@@ -257,7 +257,7 @@ contract TestSupply is TestSetup {
 
         FlashLoan flashLoan = new FlashLoan(pool);
         vm.prank(address(supplier2));
-        ERC20(dai).transfer(address(flashLoan), 10_000 ether); // to pay the premium.
+        ERC20(dai).transfer(address(flashLoan), 10_000 ether); // To pay the premium.
         flashLoan.callFlashLoan(dai, flashLoanAmount);
 
         vm.warp(block.timestamp + 1);
@@ -277,7 +277,7 @@ contract TestSupply is TestSetup {
         assertGt(gasUsed2, gasUsed1 + 1e4);
     }
 
-    function testNoIndexUpdateSkip() public {
+    function testPoolIndexGrowthInsideBlock() public {
         supplier1.approve(dai, type(uint256).max);
         supplier1.supply(aDai, 1);
 
@@ -285,7 +285,7 @@ contract TestSupply is TestSetup {
 
         FlashLoan flashLoan = new FlashLoan(pool);
         vm.prank(address(supplier2));
-        ERC20(dai).transfer(address(flashLoan), 10_000 ether); // to pay the premium.
+        ERC20(dai).transfer(address(flashLoan), 10_000 ether); // To pay the premium.
         flashLoan.callFlashLoan(dai, 10_000 ether);
 
         supplier1.supply(aDai, 1);
@@ -293,6 +293,28 @@ contract TestSupply is TestSetup {
         (, uint256 poolSupplyIndexCachedAfter, ) = morpho.poolIndexes(aDai);
 
         assertGt(poolSupplyIndexCachedAfter, poolSupplyIndexCachedBefore);
+    }
+
+    function testP2PIndexGrowthInsideBlock() public {
+        borrower1.approve(dai, type(uint256).max);
+        borrower1.supply(aDai, 10 ether);
+        borrower1.borrow(aDai, 5 ether);
+        setDefaultMaxGasForMatchingHelper(3e6, 3e6, 3e6, 0);
+        // Create delta.
+        borrower1.repay(aDai, type(uint256).max);
+
+        uint256 p2pSupplyIndexBefore = morpho.p2pSupplyIndex(aDai);
+
+        FlashLoan flashLoan = new FlashLoan(pool);
+        vm.prank(address(supplier2));
+        ERC20(dai).transfer(address(flashLoan), 10_000 ether); // To pay the premium.
+        flashLoan.callFlashLoan(dai, 10_000 ether);
+
+        borrower1.supply(aDai, 1);
+
+        uint256 p2pSupplyIndexAfter = morpho.p2pSupplyIndex(aDai);
+
+        assertGt(p2pSupplyIndexAfter, p2pSupplyIndexBefore);
     }
 
     /// @dev Helper for gas usage test

--- a/test/compound/TestSupply.t.sol
+++ b/test/compound/TestSupply.t.sol
@@ -321,6 +321,44 @@ contract TestSupply is TestSetup {
         assertGt(gasUsed2, gasUsed1 + 5e4);
     }
 
+    function testPoolIndexGrowthInsideBlock() public {
+        supplier1.approve(dai, type(uint256).max);
+        supplier1.supply(cDai, 1 ether);
+
+        (, uint256 poolSupplyIndexCachedBefore, ) = morpho.lastPoolIndexes(cDai);
+
+        vm.prank(address(supplier1));
+        ERC20(dai).transfer(cDai, 10_000 ether);
+
+        supplier1.supply(cDai, 1);
+
+        (, uint256 poolSupplyIndexCachedAfter, ) = morpho.lastPoolIndexes(cDai);
+
+        assertGt(poolSupplyIndexCachedAfter, poolSupplyIndexCachedBefore);
+    }
+
+    function testP2PIndexGrowthInsideBlock() public {
+        borrower1.approve(dai, type(uint256).max);
+        borrower1.supply(cDai, 1 ether);
+        borrower1.borrow(cDai, 0.5 ether);
+        setDefaultMaxGasForMatchingHelper(0, 0, 0, 0);
+        // Bypass the borrow repay in the same block by overwritting the storage slot lastBorrowBlock[borrower1].
+        hevm.store(address(morpho), keccak256(abi.encode(address(borrower1), 178)), 0);
+        // Create delta.
+        borrower1.repay(cDai, type(uint256).max);
+
+        uint256 p2pSupplyIndexBefore = morpho.p2pSupplyIndex(cDai);
+
+        vm.prank(address(supplier1));
+        ERC20(dai).transfer(cDai, 10_000 ether);
+
+        borrower1.supply(cDai, 1);
+
+        uint256 p2pSupplyIndexAfter = morpho.p2pSupplyIndex(cDai);
+
+        assertGt(p2pSupplyIndexAfter, p2pSupplyIndexBefore);
+    }
+
     /// @dev Helper for gas usage test
     function _getSupplyGasUsage(uint256 amount, uint256 maxGas) internal returns (uint256 gasUsed) {
         // 2 * NMAX borrowers borrow amount


### PR DESCRIPTION
This pull request fixes the index caching issue, on both AaveV2 and Compound Optimizers. The fix consists on recomputing the indexes each time (even if there has been an interaction with Morpho in the same block).